### PR TITLE
Impr/gamemode difficulty tweaking

### DIFF
--- a/frontend/public/gamemodeData/CirclefallEasy.json
+++ b/frontend/public/gamemodeData/CirclefallEasy.json
@@ -1,0 +1,14 @@
+{
+    "numWaves": 1,
+    "numLives": 1,
+    "showWaveNumber": false,
+    "waveInfo": {
+        "1": {
+            "circleRadius":40,
+            "minSpeedY": 3,
+            "maxSpeedY": 3,
+            "circlesPerSecond": 3.5,
+            "totalCircles": 100
+        }
+    }
+}

--- a/frontend/public/gamemodeData/CirclefallEasy.json
+++ b/frontend/public/gamemodeData/CirclefallEasy.json
@@ -5,9 +5,9 @@
     "waveInfo": {
         "1": {
             "circleRadius":40,
-            "minSpeedY": 3,
-            "maxSpeedY": 3,
-            "circlesPerSecond": 3.5,
+            "minSpeedY": 2.2,
+            "maxSpeedY": 2.8,
+            "circlesPerSecond": 3,
             "totalCircles": 100
         }
     }

--- a/frontend/public/gamemodeData/CirclefallHard.json
+++ b/frontend/public/gamemodeData/CirclefallHard.json
@@ -6,8 +6,8 @@
         "1": {
             "circleRadius":35,
             "minSpeedY": 3,
-            "maxSpeedY": 3,
-            "circlesPerSecond": 5,
+            "maxSpeedY": 3.6,
+            "circlesPerSecond": 5.55,
             "totalCircles": 100
         }
     }

--- a/frontend/public/gamemodeData/CirclefallHard.json
+++ b/frontend/public/gamemodeData/CirclefallHard.json
@@ -1,5 +1,14 @@
 {
-    "circleRadius":35,
-    "ySpeed": 3,
-    "circlesPerSecond": 5
+    "numWaves": 1,
+    "numLives": 101,
+    "showWaveNumber": false,
+    "waveInfo": {
+        "1": {
+            "circleRadius":35,
+            "minSpeedY": 3,
+            "maxSpeedY": 3,
+            "circlesPerSecond": 5,
+            "totalCircles": 100
+        }
+    }
 }

--- a/frontend/public/gamemodeData/CirclefallImpossible.json
+++ b/frontend/public/gamemodeData/CirclefallImpossible.json
@@ -1,5 +1,14 @@
 {
-    "circleRadius":30,
-    "ySpeed": 3,
-    "circlesPerSecond": 6.66
+    "numWaves": 1,
+    "numLives": 1,
+    "showWaveNumber": false,
+    "waveInfo": {
+        "1": {
+            "circleRadius":30,
+            "minSpeedY": 3,
+            "maxSpeedY": 3,
+            "circlesPerSecond": 6.66,
+            "totalCircles": 100
+        }
+    }
 }

--- a/frontend/public/gamemodeData/CirclefallImpossible.json
+++ b/frontend/public/gamemodeData/CirclefallImpossible.json
@@ -6,9 +6,9 @@
         "1": {
             "circleRadius":30,
             "minSpeedY": 3,
-            "maxSpeedY": 3,
+            "maxSpeedY": 4,
             "circlesPerSecond": 6.66,
-            "totalCircles": 100
+            "totalCircles": 1000000000
         }
     }
 }

--- a/frontend/public/gamemodeData/CirclefallMarathon.json
+++ b/frontend/public/gamemodeData/CirclefallMarathon.json
@@ -1,6 +1,7 @@
 {
     "numWaves": 10,
     "numLives": 1,
+    "showWaveNumber": true,
     "waveInfo": {
         "1": {
             "circleRadius":35,

--- a/frontend/public/gamemodeData/CirclefallNormal.json
+++ b/frontend/public/gamemodeData/CirclefallNormal.json
@@ -5,9 +5,9 @@
     "waveInfo": {
         "1": {
             "circleRadius":35,
-            "minSpeedY": 3,
-            "maxSpeedY": 3,
-            "circlesPerSecond": 4,
+            "minSpeedY": 2.7,
+            "maxSpeedY": 3.3,
+            "circlesPerSecond": 4.44,
             "totalCircles": 100
         }
     }

--- a/frontend/public/gamemodeData/CirclefallNormal.json
+++ b/frontend/public/gamemodeData/CirclefallNormal.json
@@ -1,5 +1,14 @@
 {
-    "circleRadius":35,
-    "ySpeed": 3,
-    "circlesPerSecond": 4
+    "numWaves": 1,
+    "numLives": 101,
+    "showWaveNumber": false,
+    "waveInfo": {
+        "1": {
+            "circleRadius":35,
+            "minSpeedY": 3,
+            "maxSpeedY": 3,
+            "circlesPerSecond": 4,
+            "totalCircles": 100
+        }
+    }
 }

--- a/frontend/src/components/GamemodeBar.jsx
+++ b/frontend/src/components/GamemodeBar.jsx
@@ -43,6 +43,13 @@ function GamemodeBar() {
               <div className="gamemode-data-buttons">
 
                 <button
+                  className={`gamemode-button ${gamemode.type === "Easy" ? "active" : ""}`}
+                  onClick={() => changeGamemode("Circlefall", "Easy")}
+                >
+                  Easy
+                </button>
+
+                <button
                   className={`gamemode-button ${gamemode.type === "Normal" ? "active" : ""}`}
                   onClick={() => changeGamemode("Circlefall", "Normal")}
                 >

--- a/frontend/src/components/P5Wrapper.jsx
+++ b/frontend/src/components/P5Wrapper.jsx
@@ -26,11 +26,11 @@ const P5Wrapper = () => {
 
     const paths = {
       Circlefall: {
-          Normal: { sketch: Circlefall, filePath: "CirclefallNormal.json" },
-          Hard: { sketch: Circlefall, filePath: "CirclefallHard.json" },
-          Impossible: { sketch: Circlefall, filePath: "CirclefallImpossible.json" },
+          Normal: { sketch: CirclefallWave, filePath: "CirclefallNormal.json" },
+          Hard: { sketch: CirclefallWave, filePath: "CirclefallHard.json" },
+          Impossible: { sketch: CirclefallWave, filePath: "CirclefallImpossible.json" },
           Marathon: { sketch: CirclefallWave, filePath: "CirclefallMarathon.json" },
-          default: { sketch: Circlefall, filePath: "CirclefallNormal.json" }
+          default: { sketch: CirclefallWave, filePath: "CirclefallNormal.json" }
       },
       Gridshot: {
           Classic: { sketch: Gridshot, filePath: "GridshotClassic.json" },

--- a/frontend/src/components/P5Wrapper.jsx
+++ b/frontend/src/components/P5Wrapper.jsx
@@ -1,10 +1,11 @@
 import React, { useRef, useEffect, useContext } from 'react';
+import { Context } from '../context/GamemodeContext';
+import './Component.css';
+
 import p5 from 'p5';
-import {Circlefall} from './../p5/Circlefall'
-import {Gridshot} from './../p5/Gridshot'
-import {Context} from '../context/GamemodeContext'
-import './Component.css'
-import CirclefallWave from '../p5/CirclefallWave';
+import { Circlefall } from './../p5/Circlefall';
+import { Gridshot } from './../p5/Gridshot';
+import { CirclefallWave } from '../p5/CirclefallWave';
 
 const P5Wrapper = () => {
   // Use context to get all variables from the sketch
@@ -26,6 +27,7 @@ const P5Wrapper = () => {
 
     const paths = {
       Circlefall: {
+          Easy: { sketch: CirclefallWave, filePath: "CirclefallEasy.json" },
           Normal: { sketch: CirclefallWave, filePath: "CirclefallNormal.json" },
           Hard: { sketch: CirclefallWave, filePath: "CirclefallHard.json" },
           Impossible: { sketch: CirclefallWave, filePath: "CirclefallImpossible.json" },

--- a/frontend/src/p5/CirclefallWave.js
+++ b/frontend/src/p5/CirclefallWave.js
@@ -154,7 +154,7 @@ export const CirclefallWave = (p, gamemodeDataFilePath, dispatch) => {
 
                 }
 
-                if (misses === lives){
+                if (misses >= lives){
                     gameState = "endgame";
                     dispatch({
                         type: 'SET_GAMESTATE',

--- a/frontend/src/p5/CirclefallWave.js
+++ b/frontend/src/p5/CirclefallWave.js
@@ -70,9 +70,11 @@ export const CirclefallWave = (p, gamemodeDataFilePath, dispatch) => {
 //
 //
             case "countdown":
-                p.fill(255);
-                p.textSize(50);
-                p.text("Wave " + waveNumber, 400, 250);
+                if (gamemodeData.showWaveNumber){
+                    p.fill(255);
+                    p.textSize(50);
+                    p.text("Wave " + waveNumber, 400, 250);
+                }
 
                 if (timer <= 0) {
                     let waveInfo = gamemodeData["waveInfo"][waveNumber.toString()]


### PR DESCRIPTION
Switched all circlefall modes to use CirclefallWave.js, this is mainly for Impossible mode to have only 1 life (Wave already had this functionality), but all other modes are compatible with this circlefall version, the old Circlefall.js is no longer needed (keeping for now)
Added both frontend react and p5 functionality for an easy mode of circlefall

Tweaked the normal, hard, impossible circlefall modes to be somewhat harder, normal is a little easier than the old hard mode, hard mode is basically like the old impossible mode, and impossible mode is well... impossible
Also added varying speeds to the circlefall modes


See commit message of 57a0cb68991eeabade3cba12431c29fc42c25ea7 for new changes

This branch and pull request is meant for testing and tweaking, ideally figure this out before v1.0 release