### PR TITLE
impr(p5): change in-game stat update dispatch

### DIFF
--- a/frontend/src/p5/CirclefallWave.js
+++ b/frontend/src/p5/CirclefallWave.js
@@ -122,6 +122,7 @@ export const CirclefallWave = (p, gamemode, context) => {
                         circles.splice(i, 1);
                         i--;
                         misses++;
+                        updateGameStats();
                     }
                 }
 
@@ -181,16 +182,6 @@ export const CirclefallWave = (p, gamemode, context) => {
                     }
                     
                 }
-
-                // Update ingame stats
-                context.dispatch({
-                    type: 'SET_INGAME_STATS', 
-                    payload: {
-                        hits: hits, 
-                        misses: misses, 
-                        misclicks: totalClicks - hits
-                    }
-                });
                 break;
 //
 //
@@ -241,6 +232,7 @@ export const CirclefallWave = (p, gamemode, context) => {
                 }
                 totalClicks++;
                 dataCollector.addFrameMousePressed(p.frameCount, circleClickedId);
+                updateGameStats();
                 break;
         }
 
@@ -258,6 +250,18 @@ export const CirclefallWave = (p, gamemode, context) => {
                 }
             });
         }
+    }
+
+    function updateGameStats(){
+        // Update ingame stats
+        context.dispatch({
+            type: 'SET_INGAME_STATS', 
+            payload: {
+                hits: hits, 
+                misses: misses, 
+                misclicks: totalClicks - hits
+            }
+        });
     }
 }
 

--- a/frontend/src/p5/Gridshot.js
+++ b/frontend/src/p5/Gridshot.js
@@ -131,16 +131,6 @@ export const Gridshot = (p, gamemode, context) => {
                     }
                 }
 
-                // Update ingame stats
-                context.dispatch({
-                    type: 'SET_INGAME_STATS', 
-                    payload: {
-                        hits: hits, 
-                        misses: 0, 
-                        misclicks: totalClicks - hits
-                    }
-                });
-
                 break;
 //
 //
@@ -204,6 +194,7 @@ export const Gridshot = (p, gamemode, context) => {
                 }
                 totalClicks++;
                 dataCollector.addFrameMousePressed(p.frameCount, circleClickedId);
+                updateGameStats();
                 break;
         }
 
@@ -243,6 +234,18 @@ export const Gridshot = (p, gamemode, context) => {
                 }
             });
         }
+    }
+
+    function updateGameStats(){
+        // Update ingame stats
+        context.dispatch({
+            type: 'SET_INGAME_STATS', 
+            payload: {
+                hits: hits, 
+                misses: 0, 
+                misclicks: totalClicks - hits
+            }
+        });
     }
 }
 


### PR DESCRIPTION
Changed the dispatch call for updating the stats to only happen when a stat-changing event happens (such as a click, circle fall off screen, etc). Should theoretically reduce application overhead, no noticeable difference though for me...