### PR TITLE
feat: 94 - use refresh token

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -99,12 +99,14 @@ exports.login = async (req, res) => {
         res.cookie('accessToken', accessToken, {
             httpOnly: true,
             secure: true, //process.env.NODE_ENV === 'production'
-            sameSite: "Strict"
+            sameSite: "Strict",
+            maxAge: 24 * 60 * 60 * 1000 // 1 day
         });
         res.cookie('refreshToken', refreshToken, {
             httpOnly: true,
             secure: true, //process.env.NODE_ENV === 'production',
-            sameSite: "Strict"
+            sameSite: "Strict",
+            maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
         });
         return res.status(200).json({ message: 'Logged in successfully' });
     } catch (err) {
@@ -133,12 +135,14 @@ exports.refresh = (req, res) => {
         res.cookie('accessToken', newAccessToken, {
             httpOnly: true,
             secure: true,
-            sameSite: 'Strict'
+            sameSite: 'Strict',
+            maxAge: 24 * 60 * 60 * 1000 // 1 day
         });
         res.cookie('refreshToken', newRefreshToken, {
             httpOnly: true,
             secure: true,
-            sameSite: 'Strict'
+            sameSite: 'Strict',
+            maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
         });
 
         res.json({ message: 'Token refreshed' });

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -108,13 +108,16 @@ exports.login = async (req, res) => {
             sameSite: "Strict",
             maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
         });
-        return res.status(200).json({ message: 'Logged in successfully' });
+        return res.status(200).json({ 
+            message: 'Logged in successfully',
+            usernameDisplay: user.usernameDisplay
+        });
     } catch (err) {
         res.status(500).json({ message: 'Login failed' });
     }
 };
 
-exports.refresh = (req, res) => {
+exports.refresh = async (req, res) => {
     const { refreshToken } = req.cookies;
 
     if (!refreshToken) {
@@ -124,6 +127,13 @@ exports.refresh = (req, res) => {
     try {
         // Verify and decode refresh token
         const decoded = jwt.verify(refreshToken, process.env.REFRESH_SECRET);
+
+        // Fetch user from data base to return display name
+        const user = await User.findById(decoded.userId);
+
+        if (!user){
+            return res.status(401).json({ message: 'User not found' });
+        }
 
         // Create new access token
         const newAccessToken = jwt.sign({ userId: decoded.userId }, process.env.JWT_SECRET, { expiresIn: '1d' });
@@ -145,7 +155,10 @@ exports.refresh = (req, res) => {
             maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
         });
 
-        res.json({ message: 'Token refreshed' });
+        res.status(200).json({ 
+            message: 'Token refreshed',
+            usernameDisplay: user.usernameDisplay
+        });
     } catch (err) {
         res.status(401).json({ message: 'Refresh token is expired or invalid' });
     }

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,9 +1,10 @@
 const express = require('express');
-const { register, login, logout } = require('../controllers/authController');
+const { register, login, logout, refresh } = require('../controllers/authController');
 const router = express.Router();
 
 router.post('/register', register);
 router.post('/login', login);
 router.post('/logout', logout);
+router.post('/refresh', refresh);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,12 +20,15 @@ function App() {
     useEffect(async () => {
         const refreshAuthToken = async () => {
             try{
+                // Call refresh endpoint
                 const response = await authRefresh();
-                console.log(response);
+
+                // If here, successful, log user in
                 authContext.authDispatch({
                     type: 'LOGIN',
                     payload: response.data.usernameDisplay
                 });
+                // Show successful login alert popup
                 menuContext.menuDispatch({
                     type: 'SHOW_ALERT',
                     payload: {
@@ -34,6 +37,7 @@ function App() {
                     }
                 });
             } catch (error) {
+                // If here, refresh failed, open login popup
                 menuContext.menuDispatch({
                     type: 'OPEN_POPUP',
                     payload: 'login'

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 import './App.css';
 import NavBar from './components/NavBar';
 import GamemodeBar from './components/GamemodeBar';
@@ -6,32 +6,57 @@ import P5Wrapper from './components/P5Wrapper';
 import PostGame from './components/PostGame';
 import Popup from './components/Popup';
 import Footer from './components/Footer';
-import { GamemodeProvider } from './context/GamemodeContext';
-import { MenuProvider } from './context/MenuContext';
-import { AuthProvider } from './context/AuthContext';
+import { MenuContext } from './context/MenuContext';
+import { AuthContext } from './context/AuthContext';
+import { authRefresh } from './api';
+
 
 
 function App() {
+    const authContext = useContext(AuthContext);
+    const menuContext = useContext(MenuContext);
+
+    // On app mounted, use refresh token
+    useEffect(async () => {
+        const refreshAuthToken = async () => {
+            try{
+                const response = await authRefresh();
+                authContext.authDispatch({
+                    type: 'LOGIN',
+                    payload: 'test username'
+                });
+                menuContext.menuDispatch({
+                    type: 'SHOW_ALERT',
+                    payload: {
+                        type: 'success',
+                        message: 'Login successful'
+                    }
+                });
+            } catch (error) {
+                menuContext.menuDispatch({
+                    type: 'OPEN_POPUP',
+                    payload: 'login'
+                });
+            }
+        }
+        refreshAuthToken();
+    }, []);
 
     return (
         <div className='App'>
-            <GamemodeProvider><MenuProvider><AuthProvider>
+            <Popup/>
+            <NavBar/>
 
-                <Popup/>
-                <NavBar/>
+            <GamemodeBar/>
 
-                <GamemodeBar/>
+            <div className='main-content'>
+                <PostGame/>
+                <P5Wrapper/>
+            </div>
 
-                <div className='main-content'>
-                    <PostGame/>
-                    <P5Wrapper/>
-                </div>
-
-                <Footer/>
-                
-                </AuthProvider></MenuProvider></GamemodeProvider>
+            <Footer/>
         </div>
     )
 }
 
-export default App
+export default App;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,9 +21,10 @@ function App() {
         const refreshAuthToken = async () => {
             try{
                 const response = await authRefresh();
+                console.log(response);
                 authContext.authDispatch({
                     type: 'LOGIN',
-                    payload: 'test username'
+                    payload: response.data.usernameDisplay
                 });
                 menuContext.menuDispatch({
                     type: 'SHOW_ALERT',

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -25,7 +25,11 @@ export const login = (identifier, password) => API.post(
     }
 );
 
+// Logout (deletes cookies)
 export const logout = () => API.post('/auth/logout');
+
+// Refresh jwt tokens in cookies
+export const authRefresh = () => API.post('/auth/refresh');
 
 // Submit score
 export const submitScore = (gamemode, score, hits, misses, misclicks) => API.post(

--- a/frontend/src/components/popups/Login.jsx
+++ b/frontend/src/components/popups/Login.jsx
@@ -33,22 +33,26 @@ function Login() {
             const response = await login(loginFormData.identifier, loginFormData.password);
             authDispatch({
                 type: 'LOGIN',
-                payload: loginFormData.identifier
+                payload: response.data.usernameDisplay
             });
             menuDispatch({
                 type: 'CLOSE_POPUP'
             });
             menuDispatch({
                 type: 'SHOW_ALERT',
-                payload: {type: 'success',
-                          message: 'Login Successful!' }
-            })
+                payload: {
+                    type: 'success',
+                    message: 'Login Successful!' 
+                }
+            });
         } catch (error) {
             menuDispatch({
                 type: 'SHOW_ALERT',
-                payload: {type: 'error',
-                          message: error.response.data.message }
-            })
+                payload: {
+                    type: 'error',
+                    message: error.response.data.message 
+                }
+            });
         }
     };
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,9 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
+import { GamemodeProvider } from './context/GamemodeContext';
+import { MenuProvider } from './context/MenuContext';
+import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <GamemodeProvider><MenuProvider><AuthProvider>
+      <App />
+    </AuthProvider></MenuProvider></GamemodeProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Changes: 

- Added `maxAge` property to cookies in backend, this makes it so they persist between sessions (when user closes browser), this is a different property and functionality from the jwt token expiration thing

- Moved all providers to `main.jsx`, this was so I could use context in App.jsx (instead of having to do the next bullet in a weird place)

- Implemented refresh token functionality. This takes place when `App.jsx` is mounted with `useEffect()`. When this is a success, the successful login alert popup appears and the user is logged in according to AuthContext. When this fails, the login popup appears, should encourage new people to register.

- Added functionality in backend so that the login and refresh endpoints include the `usernameDisplay` in their response. This was required in the refresh functionality to know their username, it also fixed the issue where someone could put their email as the identifier in the login form and it would say the username is the email. 

## Potential New Issues/Discussion

We should think about what to do when the user is refreshed. I was thinking perhaps a popup that is like welcome back and has release notes. I'm sure we can think of a better idea, or maybe nothing at all.

## Comments

Please review this thoroughly, I have not worked extensively in the frontend in a while. Call out anything that looks weird, even if it definitely works.