### PR TITLE
feat: 31 - gridshot scoring

### DIFF
--- a/frontend/public/gamemodeData/GridshotClassic.json
+++ b/frontend/public/gamemodeData/GridshotClassic.json
@@ -9,6 +9,7 @@
     "circleRadius": 45,
     "scoring": {
         "scorePerHit": 637,
-        "scorePerMiss": -123
+        "scorePerMiss": -123,
+        "precisionBonus": 100
     }
 }

--- a/frontend/public/gamemodeData/GridshotClassic.json
+++ b/frontend/public/gamemodeData/GridshotClassic.json
@@ -6,5 +6,9 @@
     "yMin": 100,
     "yMax": 500,
     "numCircles": 3,
-    "circleRadius": 45
+    "circleRadius": 45,
+    "scoring": {
+        "scorePerHit": 637,
+        "scorePerMiss": -123
+    }
 }

--- a/frontend/public/gamemodeData/GridshotClassic.json
+++ b/frontend/public/gamemodeData/GridshotClassic.json
@@ -7,6 +7,7 @@
     "yMax": 500,
     "numCircles": 3,
     "circleRadius": 45,
+    "taxicabRadius": 0,
     "scoring": {
         "scorePerHit": 637,
         "scorePerMiss": -123,

--- a/frontend/public/gamemodeData/GridshotMini.json
+++ b/frontend/public/gamemodeData/GridshotMini.json
@@ -6,5 +6,9 @@
     "yMin": 50,
     "yMax": 550,
     "numCircles": 5,
-    "circleRadius": 10
+    "circleRadius": 10,
+    "scoring": {
+        "scorePerHit": 1333,
+        "scorePerMiss": -436
+    }
 }

--- a/frontend/public/gamemodeData/GridshotMini.json
+++ b/frontend/public/gamemodeData/GridshotMini.json
@@ -9,6 +9,7 @@
     "circleRadius": 10,
     "scoring": {
         "scorePerHit": 1333,
-        "scorePerMiss": -436
+        "scorePerMiss": -436,
+        "precisionBonus": 200
     }
 }

--- a/frontend/public/gamemodeData/GridshotMini.json
+++ b/frontend/public/gamemodeData/GridshotMini.json
@@ -7,6 +7,7 @@
     "yMax": 550,
     "numCircles": 5,
     "circleRadius": 10,
+    "taxicabRadius": 7,
     "scoring": {
         "scorePerHit": 1333,
         "scorePerMiss": -436,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,7 +17,7 @@ function App() {
     const menuContext = useContext(MenuContext);
 
     // On app mounted, use refresh token
-    useEffect(async () => {
+    useEffect(() => {
         const refreshAuthToken = async () => {
             try{
                 // Call refresh endpoint

--- a/frontend/src/p5/Gridshot.js
+++ b/frontend/src/p5/Gridshot.js
@@ -27,6 +27,7 @@ export const Gridshot = (p, gamemode, context) => {
     let yMax;
     let numCircles;
     let circleRadius;
+    let taxicabRadius;
 
     // Scoring Gamemode Data Variables
     let scorePerHit;
@@ -54,11 +55,12 @@ export const Gridshot = (p, gamemode, context) => {
         yMax = gamemodeData["yMax"];
         numCircles = gamemodeData["numCircles"];
         circleRadius = gamemodeData["circleRadius"];
+        taxicabRadius = gamemodeData["taxicabRadius"];
 
         let scoringData = gamemodeData["scoring"];
         scorePerHit = scoringData["scorePerHit"];
         scorePerMiss = scoringData["scorePerMiss"];
-        precisionBonus = scoringData["precisionBonus"]
+        precisionBonus = scoringData["precisionBonus"];
 
         // Initialize Grid
         grid = new Grid(numRows, numCols, xMin, xMax, yMin, yMax);
@@ -228,7 +230,7 @@ export const Gridshot = (p, gamemode, context) => {
     function addNewCircle(){
         let row = p.int(p.random(0, numRows));
         let col = p.int(p.random(0, numCols));
-        while(grid.isPointOccupied(row, col)){
+        while(!isValidSpawnPoint(row, col)){
             row = p.int(p.random(0, numRows));
             col = p.int(p.random(0, numCols));
         }
@@ -275,6 +277,19 @@ export const Gridshot = (p, gamemode, context) => {
     function calculatePrecisionBonus(mouseX, mouseY, circleX, circleY){
         let distFromCenter = Math.sqrt(Math.pow((circleX - mouseX), 2) + Math.pow((circleY - mouseY), 2));
         return ((circleRadius-distFromCenter)/circleRadius) * precisionBonus;
+    }
+
+    function isValidSpawnPoint(row, col){
+        for (let i = row - taxicabRadius; i <= row + taxicabRadius; i++){
+            for (let j = col - taxicabRadius; j <= col + taxicabRadius; j++){
+                if (Math.abs(i-row) + Math.abs(j-col) <= taxicabRadius){
+                    if (grid.isPointOccupied(i, j)){
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
     }
 }
 

--- a/frontend/src/p5/Gridshot.js
+++ b/frontend/src/p5/Gridshot.js
@@ -16,8 +16,9 @@ export const Gridshot = (p, gamemode, context) => {
     // Stats Variables
     let totalClicks;
     let hits;
+    let score;
 
-    // Gamemode Data Variables
+    // General Gamemode Data Variables
     let numRows;
     let numCols;
     let xMin;
@@ -26,6 +27,10 @@ export const Gridshot = (p, gamemode, context) => {
     let yMax;
     let numCircles;
     let circleRadius;
+
+    // Scoring Gamemode Data Variables
+    let scorePerHit;
+    let scorePerMiss;
 
     
     //-----------Preload-----------//
@@ -49,6 +54,10 @@ export const Gridshot = (p, gamemode, context) => {
         numCircles = gamemodeData["numCircles"];
         circleRadius = gamemodeData["circleRadius"];
 
+        let scoringData = gamemodeData["scoring"];
+        scorePerHit = scoringData["scorePerHit"];
+        scorePerMiss = scoringData["scorePerMiss"];
+
         // Initialize Grid
         grid = new Grid(numRows, numCols, xMin, xMax, yMin, yMax);
         circles = [];
@@ -63,6 +72,7 @@ export const Gridshot = (p, gamemode, context) => {
 
         totalClicks = 0;
         hits = 0;
+        score = 0;
         totalCirclesSpawned = 0;
 
         p.textAlign(p.CENTER);
@@ -121,7 +131,7 @@ export const Gridshot = (p, gamemode, context) => {
                         payload: gameState 
                     });
                     try{
-                        let response = submitScore(gamemode, hits-(totalClicks-hits), hits, 0, totalClicks-hits);
+                        let response = submitScore(gamemode, score, hits, 0, totalClicks-hits);
                         // if (!response.ok){
                         //     throw new Error(`HTTP error! Status: ${response.status}`);
                         // }
@@ -194,6 +204,11 @@ export const Gridshot = (p, gamemode, context) => {
                 }
                 totalClicks++;
                 dataCollector.addFrameMousePressed(p.frameCount, circleClickedId);
+                if (circleClickedId){
+                    score += scorePerHit;
+                } else{
+                    score += scorePerMiss;
+                }
                 updateGameStats();
                 break;
         }
@@ -244,7 +259,7 @@ export const Gridshot = (p, gamemode, context) => {
                 hits: hits, 
                 misses: 0, 
                 misclicks: totalClicks - hits,
-                score: hits - (totalClicks - hits)
+                score: score
             }
         });
     }

--- a/frontend/src/p5/Gridshot.js
+++ b/frontend/src/p5/Gridshot.js
@@ -281,11 +281,10 @@ export const Gridshot = (p, gamemode, context) => {
 
     function isValidSpawnPoint(row, col){
         for (let i = row - taxicabRadius; i <= row + taxicabRadius; i++){
-            for (let j = col - taxicabRadius; j <= col + taxicabRadius; j++){
-                if (Math.abs(i-row) + Math.abs(j-col) <= taxicabRadius){
-                    if (grid.isPointOccupied(i, j)){
-                        return false;
-                    }
+            let rowsFromCenter = Math.abs(i - row);
+            for (let j = col - taxicabRadius + rowsFromCenter; j <= col + taxicabRadius - rowsFromCenter; j++){
+                if (grid.isPointOccupied(i, j)){
+                    return false;
                 }
             }
         }

--- a/frontend/src/p5/p5components/Grid.js
+++ b/frontend/src/p5/p5components/Grid.js
@@ -16,7 +16,7 @@ class Grid {
     
     //------Utility------//
     isPointOccupied(row, col){
-        return this.grid[row][col].occupied;
+        return this.grid?.[row]?.[col]?.occupied ?? false;
     }
     setPointOccupied(row, col){
         this.grid[row][col].occupied = true;


### PR DESCRIPTION
## Changes

Included issues #31, #110 

- Added scoring for non-gridshot-wave modes (classic/mini)
  - classic: +637 / hit, -123 / miss
  - mini: +1333 / hit, -436 / miss
  
- Added a precision bonus for scoring in gridshot classic/mini, these work by taking the distance from the circle clicked and using that as a precision percentage to apply to the set bonus in the gamemodeData files for each mode.
  - classic: +100 bonus for 100%
  - mini: +200 bonus for 100%
  
- Added functionality for controlling how circles in gridshot can spawn relative to each other. For this I used taxicab distance (or Manhattan distance) to determine a radius around each circle that there can't be another circle.

## Questions / Discussion

Was the precision thing a good idea? I'm still not sure if it matters, just thought that it would make the score a little more dynamic. Perhaps we have an average precision percentage in the end game screen as well.

What other ways can we add dynamic scoring? Streak based bonuses? I don't have any other ideas.