### PR TITLE
fix(frontend): tab goes to next field on login/signup popups

### DIFF
--- a/frontend/src/components/P5Wrapper.jsx
+++ b/frontend/src/components/P5Wrapper.jsx
@@ -64,7 +64,7 @@ const P5Wrapper = () => {
   useEffect(() => {
     // Function to handle keypresses
     const handleKeyDown = (event) => {
-      if (event.key === 'Tab'){
+      if (event.key === 'Tab' && !popup.visible){
         event.preventDefault();
         handleReset();
       }
@@ -74,7 +74,7 @@ const P5Wrapper = () => {
     return () => {
       window.removeEventListener('keydown', handleKeyDown); // Remove listener
     };
-  }, []);
+  }, [popup.visible]);
 
   // Render a div that will be used as the container for the p5.js canvas
   return (

--- a/frontend/src/components/popups/Signup.jsx
+++ b/frontend/src/components/popups/Signup.jsx
@@ -53,7 +53,7 @@ function Signup() {
             <Header>register</Header>
             <RegisterForm autoComplete="off">
                 <RegisterFormInput
-                    type="text"
+                    type="email"
                     id="email"
                     value={registerFormData.email}
                     onChange={handleInputChange}


### PR DESCRIPTION
Very simple fix, just included not having the event listener for pressing tab be present when in a popup. This issue was actually caused by the `event.preventDefault()` when tab is pressed, which makes sense.

Also changed the type for the email field in the signup form, this probably does nothing but...

#77 probably is not necessary anymore, but I don't remember if pressing tab and resetting the game was the reason we wanted the placeholder