### PR TITLE
chore(frontend): remove light mode background color

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -45,16 +45,3 @@ button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}


### PR DESCRIPTION
Removed the light mode css for the background color that was in index.css, themes will be added in their own custom functionality.

Perhaps create an issue for removing App.css and index.css? Maybe not, but it does seem like there's a bunch of useless stuff in those, most can get removed maybe?