### PR TITLE
impr: #127 - Sync user scores in database and local memory

### DIFF
--- a/backend/controllers/scoreController.js
+++ b/backend/controllers/scoreController.js
@@ -31,7 +31,7 @@ exports.getScoresByUsername = async (req, res) => {
         const { username } = req.params;
 
         // Find scores by username
-        const scores = await Score.find({ username: username });
+        const scores = await Score.find({ username: username }).select('-_id -__v -username -usernameDisplay');
 
         res.status(200).json(scores);
     } catch (err) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -43,7 +43,7 @@ export const submitScore = (gamemode, score, hits, misses, misclicks) => API.pos
             misclicks: misclicks
         }
     }
-)
+);
 
 // Get scores by username
 export const getScoresByUsername = (username) => API.get('/scores/username/' + username);

--- a/frontend/src/components/P5Wrapper.jsx
+++ b/frontend/src/components/P5Wrapper.jsx
@@ -57,7 +57,7 @@ const P5Wrapper = () => {
 
     const p5Instance = new p5((p) => sketch(p, gamemodeDataFilePath,
       {
-        dispatch: gameContext.gamemodeDispatch,
+        gamemodeDispatch: gameContext.gamemodeDispatch,
         userDispatch: userContext.userDispatch, 
         popupVisible: popup.visible, 
         hitSound: userContext.settings.hitSound,

--- a/frontend/src/components/P5Wrapper.jsx
+++ b/frontend/src/components/P5Wrapper.jsx
@@ -57,7 +57,8 @@ const P5Wrapper = () => {
 
     const p5Instance = new p5((p) => sketch(p, gamemodeDataFilePath,
       {
-        dispatch: gameContext.gamemodeDispatch, 
+        dispatch: gameContext.gamemodeDispatch,
+        userDispatch: userContext.userDispatch, 
         popupVisible: popup.visible, 
         hitSound: userContext.settings.hitSound,
         hitSoundVolume: (userContext.settings.masterVolume/100) * (userContext.settings.hitSoundVolume/100)

--- a/frontend/src/components/popups/Profile.jsx
+++ b/frontend/src/components/popups/Profile.jsx
@@ -4,15 +4,15 @@ import { MenuContext } from '../../context/MenuContext';
 import { logout } from '../../api';
 
 function Profile() {
-    const { username, userDispatch } = useContext(UserContext);
+    const userContext = useContext(UserContext);
     const { menuDispatch } = useContext(MenuContext);
-
+    
     // Logout
     const handleLogout = async (e) => {
         e.preventDefault();
         try {
             const response = await logout();
-            userDispatch({
+            userContext.userDispatch({
                 type: 'LOGOUT'
             })
             menuDispatch({
@@ -36,7 +36,7 @@ function Profile() {
     return (
         <>
             <h1>profile</h1>
-            <p>{username}</p>
+            <p>{userContext.username}</p>
             <button onClick={handleLogout}>logout</button>
         </>
     );

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -17,7 +17,8 @@ export const Reducer = (state, action) => {
             return {
                 ...state,
                 loggedin: false,
-                username: undefined
+                username: undefined,
+                scores: [],
             }
         
         case 'UPDATE_SETTING':
@@ -27,6 +28,25 @@ export const Reducer = (state, action) => {
                     ...state.settings,
                     [action.settingName]: action.payload
                 }
+            }
+        case 'ADD_SCORE':
+            return{
+                ...state,
+                scores: [
+                    ...state.scores,
+                    {
+                        stats: {
+                            hits: action.payload.hits,
+                            misses: action.payload.misses,
+                            misclicks: action.payload.misclicks,
+                        },
+                        gamemode: action.payload.gamemode,
+                        score: action.payload.score,
+                        date: new Date().toISOString(),
+
+                    }
+                ]
+
             }
         default:
             return state;
@@ -59,6 +79,7 @@ export const UserProvider = ({ children }) => {
                 loggedin: state.loggedin,
                 username: state.username,
                 settings: state.settings,
+                scores: state.scores,
                 userDispatch
             }}
         >

--- a/frontend/src/p5/CirclefallWave.js
+++ b/frontend/src/p5/CirclefallWave.js
@@ -179,15 +179,22 @@ export const CirclefallWave = (p, gamemode, context) => {
                         type: 'SET_GAMESTATE',
                         payload: gameState
                     });
-                    try{
-                        let response = submitScore(gamemode, hits-misses-(totalClicks-hits), hits, misses, totalClicks - hits);
-                        // if (!response.ok){
-                        //     throw new Error(`HTTP error! Status: ${response.status}`);
-                        // }
-                        // console.log("Submit Score Successful");
-                    }catch (error){
-                        console.log("Submit Score Failed:", error);
-                    }
+                    submitScore(gamemode, hits-misses-(totalClicks-hits), hits, misses, totalClicks - hits)
+                    .then(response => {
+                        context.userDispatch({
+                            type: 'ADD_SCORE',
+                            payload: {
+                                hits: hits,
+                                misses: misses,
+                                misclicks: totalClicks-hits,
+                                score: hits-misses-(totalClicks-hits), 
+                                gamemode: gamemode,
+                            }
+                        });
+                    })
+                    .catch(error => {
+                        console.log("Submit Score Failed");
+                    });   
                     
                 }
                 break;

--- a/frontend/src/p5/CirclefallWave.js
+++ b/frontend/src/p5/CirclefallWave.js
@@ -48,7 +48,7 @@ export const CirclefallWave = (p, gamemode, context) => {
         p.createCanvas(800, 600);
 
         gameState = "pregame";
-        context.dispatch({
+        context.gamemodeDispatch({
             type: 'SET_GAMESTATE',
             payload: gameState
         });
@@ -94,7 +94,7 @@ export const CirclefallWave = (p, gamemode, context) => {
                     circlesPerSecond = waveInfo["circlesPerSecond"];
 
                     gameState = "ingame";
-                    context.dispatch({
+                    context.gamemodeDispatch({
                         type: 'SET_GAMESTATE',
                         payload: gameState
                     });
@@ -139,7 +139,7 @@ export const CirclefallWave = (p, gamemode, context) => {
                 if (waveCirclesSpawned >= maxWaveCircles && circles.length === 0){
                     if (waveNumber >= maxWaves){
                         gameState = "endgame";
-                        context.dispatch({
+                        context.gamemodeDispatch({
                             type: 'SET_GAMESTATE',
                             payload: gameState
                         });
@@ -156,13 +156,13 @@ export const CirclefallWave = (p, gamemode, context) => {
                     else{
                         waveNumber++;
                         gameState = "countdown";
-                        context.dispatch({
+                        context.gamemodeDispatch({
                             type: 'SET_GAMESTATE',
                             payload: gameState
                         });
                         timer = 3;
                         timerId = setInterval(handleTimer, 1000);
-                        context.dispatch({
+                        context.gamemodeDispatch({
                             type: 'SET_TIMER',
                             payload: {
                                 timer: timer,
@@ -175,7 +175,7 @@ export const CirclefallWave = (p, gamemode, context) => {
 
                 if (misses >= lives){
                     gameState = "endgame";
-                    context.dispatch({
+                    context.gamemodeDispatch({
                         type: 'SET_GAMESTATE',
                         payload: gameState
                     });
@@ -217,7 +217,7 @@ export const CirclefallWave = (p, gamemode, context) => {
                 if (!(context.popupVisible) && p.mouseX > 0 && p.mouseX < 800 && p.mouseY > 0 && p.mouseY < 600){
                     timer = 3;
                     timerId = setInterval(handleTimer, 1000);
-                    context.dispatch({
+                    context.gamemodeDispatch({
                         type: 'SET_TIMER',
                         payload: {
                             timer: timer,
@@ -226,7 +226,7 @@ export const CirclefallWave = (p, gamemode, context) => {
                     });
 
                     gameState = "countdown";
-                    context.dispatch({
+                    context.gamemodeDispatch({
                         type: 'SET_GAMESTATE',
                         payload: gameState
                     });
@@ -261,7 +261,7 @@ export const CirclefallWave = (p, gamemode, context) => {
     function handleTimer(){
         if (timer > 0) {
             timer--;
-            context.dispatch({
+            context.gamemodeDispatch({
                 type: 'SET_TIMER',
                 payload: {
                     timer: timer,
@@ -273,7 +273,7 @@ export const CirclefallWave = (p, gamemode, context) => {
 
     function updateGameStats(){
         // Update ingame stats
-        context.dispatch({
+        context.gamemodeDispatch({
             type: 'SET_INGAME_STATS', 
             payload: {
                 hits: hits, 

--- a/frontend/src/p5/Gridshot.js
+++ b/frontend/src/p5/Gridshot.js
@@ -136,21 +136,28 @@ export const Gridshot = (p, gamemode, context) => {
                 
                 if (timer <= 0) {
                     gameState = "endgame";
-                    clearInterval(timerId)
+                    clearInterval(timerId);
                     // Update game state in context
                     context.dispatch({ 
                         type: 'SET_GAMESTATE',
                         payload: gameState 
                     });
-                    try{
-                        let response = submitScore(gamemode, p.int(score), hits, 0, totalClicks-hits);
-                        // if (!response.ok){
-                        //     throw new Error(`HTTP error! Status: ${response.status}`);
-                        // }
-                        // console.log("Submit Score Successful");
-                    }catch (error){
-                        console.log("Submit Score Failed:", error);
-                    }
+                    submitScore(gamemode, p.int(score), hits, 0, totalClicks-hits)
+                            .then(response => {
+                                context.userDispatch({
+                                    type: 'ADD_SCORE',
+                                    payload: {
+                                        hits: hits,
+                                        misses: 0,
+                                        misclicks: totalClicks-hits,
+                                        score: p.int(score), 
+                                        gamemode: gamemode,
+                                    }
+                                });
+                            })
+                            .catch(error => {
+                                console.log("Submit Score Failed");
+                            });
                 }
 
                 break;

--- a/frontend/src/p5/Gridshot.js
+++ b/frontend/src/p5/Gridshot.js
@@ -77,7 +77,7 @@ export const Gridshot = (p, gamemode, context) => {
 
         gameState = "pregame";
         // Initialize game state in context
-        context.dispatch({
+        context.gamemodeDispatch({
             type: 'SET_GAMESTATE',
             payload: gameState
         });
@@ -107,7 +107,7 @@ export const Gridshot = (p, gamemode, context) => {
 
                 if (timer <= 0) {
                     timer = 30;
-                    context.dispatch({
+                    context.gamemodeDispatch({
                         type: 'SET_TIMER',
                         payload: {
                             timer: timer, 
@@ -117,7 +117,7 @@ export const Gridshot = (p, gamemode, context) => {
 
                     gameState = "ingame";
                     // Update game state in context
-                    context.dispatch({
+                    context.gamemodeDispatch({
                         type: 'SET_GAMESTATE',
                         payload: gameState
                     });
@@ -138,7 +138,7 @@ export const Gridshot = (p, gamemode, context) => {
                     gameState = "endgame";
                     clearInterval(timerId);
                     // Update game state in context
-                    context.dispatch({ 
+                    context.gamemodeDispatch({ 
                         type: 'SET_GAMESTATE',
                         payload: gameState 
                     });
@@ -179,7 +179,7 @@ export const Gridshot = (p, gamemode, context) => {
                     // Initialize timer
                     timer = 3;
                     timerId = setInterval(handleTimer, 1000);
-                    context.dispatch({  
+                    context.gamemodeDispatch({  
                         type: 'SET_TIMER', 
                         payload: {
                             timer: timer, 
@@ -189,7 +189,10 @@ export const Gridshot = (p, gamemode, context) => {
 
                     // Update game state
                     gameState = "countdown";
-                    context.dispatch({ type: 'SET_GAMESTATE', payload: gameState }); // Update game state in context
+                    context.gamemodeDispatch({ // Update game state in context
+                        type: 'SET_GAMESTATE', 
+                        payload: gameState 
+                    }); 
 
                     // Initialize circles
                     for(let i = 0; i < numCircles; i++){ 
@@ -270,7 +273,7 @@ export const Gridshot = (p, gamemode, context) => {
     function handleTimer(){
         if (timer > 0) {
             timer--;
-            context.dispatch({
+            context.gamemodeDispatch({
                 type: 'SET_TIMER',
                 payload: {
                     timer: timer, 
@@ -282,7 +285,7 @@ export const Gridshot = (p, gamemode, context) => {
 
     function updateGameStats(){
         // Update ingame stats
-        context.dispatch({
+        context.gamemodeDispatch({
             type: 'SET_INGAME_STATS', 
             payload: {
                 hits: hits, 

--- a/frontend/src/p5/GridshotWave.js
+++ b/frontend/src/p5/GridshotWave.js
@@ -226,21 +226,29 @@ export const GridshotWave = (p, gamemode, context) => {
                     }
                     else{
                         gameState = "endgame";
-                        clearInterval(timerId)
+                        clearInterval(timerId);
                         // Update game state in context
                         context.dispatch({ 
                             type: 'SET_GAMESTATE',
                             payload: gameState 
                         });
-                        try{
-                            let response = submitScore(gamemode, score, hits, 0, totalClicks-hits);
-                            // if (!response.ok){
-                            //     throw new Error(`HTTP error! Status: ${response.status}`);
-                            // }
-                            // console.log("Submit Score Successful");
-                        }catch (error){
-                            console.log("Submit Score Failed:", error);
-                        }
+                    
+                        submitScore(gamemode, score, hits, 0, totalClicks-hits)
+                            .then(response => {
+                                context.userDispatch({
+                                    type: 'ADD_SCORE',
+                                    payload: {
+                                        hits: hits,
+                                        misses: 0,
+                                        misclicks: totalClicks-hits,
+                                        score: score, 
+                                        gamemode: gamemode,
+                                    }
+                                });
+                            })
+                            .catch(error => {
+                                console.log("Submit Score Failed");
+                            });        
                     }
 
                 }

--- a/frontend/src/p5/GridshotWave.js
+++ b/frontend/src/p5/GridshotWave.js
@@ -73,7 +73,7 @@ export const GridshotWave = (p, gamemode, context) => {
 
         gameState = "pregame";
         // Initialize game state in context
-        context.dispatch({
+        context.gamemodeDispatch({
             type: 'SET_GAMESTATE',
             payload: gameState
         });
@@ -104,7 +104,7 @@ export const GridshotWave = (p, gamemode, context) => {
                 if (timer <= 0) {
                     gameState = "ingame";
                     // Update game state in context
-                    context.dispatch({
+                    context.gamemodeDispatch({
                         type: 'SET_GAMESTATE',
                         payload: gameState
                     });
@@ -117,7 +117,7 @@ export const GridshotWave = (p, gamemode, context) => {
 
                 // Update score 10 times/s
                 if (p.frameCount % 6 === 0){
-                    context.dispatch({
+                    context.gamemodeDispatch({
                         type: 'SET_SCORE',
                         payload: score
                     });
@@ -149,7 +149,7 @@ export const GridshotWave = (p, gamemode, context) => {
                     // Initialize timer
                     timer = 3;
                     timerId = setInterval(handleTimer, 1000);
-                    context.dispatch({  
+                    context.gamemodeDispatch({  
                         type: 'SET_TIMER', 
                         payload: {
                             timer: timer, 
@@ -159,7 +159,10 @@ export const GridshotWave = (p, gamemode, context) => {
 
                     // Update game state
                     gameState = "countdown";
-                    context.dispatch({ type: 'SET_GAMESTATE', payload: gameState }); // Update game state in context
+                    context.gamemodeDispatch({  // Update game state in context
+                        type: 'SET_GAMESTATE', 
+                        payload: gameState 
+                    });
 
                     // Initialize circles
                     for(let i = 0; i < numCircles; i++){ 
@@ -228,7 +231,7 @@ export const GridshotWave = (p, gamemode, context) => {
                         gameState = "endgame";
                         clearInterval(timerId);
                         // Update game state in context
-                        context.dispatch({ 
+                        context.gamemodeDispatch({ 
                             type: 'SET_GAMESTATE',
                             payload: gameState 
                         });
@@ -284,7 +287,7 @@ export const GridshotWave = (p, gamemode, context) => {
     function handleTimer(){
         if (timer > 0) {
             timer--;
-            context.dispatch({
+            context.gamemodeDispatch({
                 type: 'SET_TIMER',
                 payload: {
                     timer: timer, 
@@ -296,7 +299,7 @@ export const GridshotWave = (p, gamemode, context) => {
 
     function updateGameStats(){
         // Update ingame stats
-        context.dispatch({
+        context.gamemodeDispatch({
             type: 'SET_INGAME_STATS', 
             payload: {
                 hits: hits, 


### PR DESCRIPTION
## Changes

- Added `ADD_SCORE` action type to the user dispatch

- Changed the old submitScore funcitonality in the p5 sketches to have a promise structure
  -  If the response is a success, use the new user dispatch call to sync what was submitted to the database with userContext.scores
  - If response is a fail, print failed

- Changed the name of `context.dispatch` to `context.gamemodeDispatch` in `P5Wrapper.jsx` props, for better clarity since two dispatches are being passed to the sketches

- Removed unused information from the get scores endpoint (random indices, username indices)